### PR TITLE
Create roles and admin pages

### DIFF
--- a/app/controllers/access_codes_controller.rb
+++ b/app/controllers/access_codes_controller.rb
@@ -10,7 +10,7 @@ class AccessCodesController < ApplicationController
     begin
       AccessCode.generate!(params['access_code']['email'])
     rescue => e
-      flash[:danger] = 'An access code already exists for this email'
+      flash[:alert] = 'An access code already exists for this email'
     end
     redirect_to access_codes_path
   end
@@ -24,6 +24,10 @@ class AccessCodesController < ApplicationController
   private
 
   def verify_admin
-    current_user.present? && current_user.admin?
+    return if current_user.present? && current_user.admin?
+
+    flash[:alert] = "You don't have permissions to access codes, please " \
+                    'an administrator.'
+    redirect_to root_path
   end
 end

--- a/app/controllers/access_codes_controller.rb
+++ b/app/controllers/access_codes_controller.rb
@@ -1,0 +1,29 @@
+class AccessCodesController < ApplicationController
+  before_action :verify_admin
+
+  def index
+    @access_codes = AccessCode.all
+    @new_access_code = AccessCode.new
+  end
+
+  def create
+    begin
+      AccessCode.generate!(params['access_code']['email'])
+    rescue => e
+      flash[:danger] = 'An access code already exists for this email'
+    end
+    redirect_to access_codes_path
+  end
+
+  def destroy
+    access_code = AccessCode.find(params[:id])
+    access_code.destroy!
+    redirect_to access_codes_path
+  end
+
+  private
+
+  def verify_admin
+    current_user.present? && current_user.admin?
+  end
+end

--- a/app/views/access_codes/index.html.erb
+++ b/app/views/access_codes/index.html.erb
@@ -1,0 +1,46 @@
+<h1>Access Codes</h1>
+
+<table>
+  <tr>
+    <th>
+      Email
+    </th>
+    <th>
+      Access Code
+    </th>
+    <th>
+      Applied?
+    </th>
+    <th>
+      Expired?
+    </th>
+    <th>
+      Delete!
+    </th>
+  </tr>
+  <% @access_codes.each do |access_code| %>
+    <tr>
+      <td>
+        <%= access_code.email %>
+      </td>
+      <td>
+        <%= access_code.code %>
+      </td>
+      <td>
+        <%= access_code.applied? ? 'Yes' : 'No' %>
+      </td>
+      <td>
+        <%= access_code.expired? ? 'Yes' : 'No' %>
+      </td>
+      <td>
+        <%= link_to 'Destroy', access_code_path(access_code),
+            data: {:confirm => 'Are you sure?'}, :method => :delete %>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
+<%= simple_form_for @new_access_code do |f| %>
+  <%= f.input :email %>
+  <%= f.button :submit %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Rails.application.routes.draw do
   end
 
   resources :stories
+
+  scope '/admin' do
+    resources :access_codes, only: [:index, :create, :destroy]
+  end
 end

--- a/db/migrate/20170305012716_add_admin_to_users.rb
+++ b/db/migrate/20170305012716_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170305004936) do
+ActiveRecord::Schema.define(version: 20170305012716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,18 +54,18 @@ ActiveRecord::Schema.define(version: 20170305004936) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.string   "gender"
     t.integer  "age"
     t.string   "religion"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20170305004936) do
     t.string   "username"
     t.string   "city"
     t.string   "state"
+    t.boolean  "admin",                  default: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
- Add `admin` boolean onto the user table
- Create a `/admin/access_codes` page for viewing, creating, and destroying access codes
- Add permissions around access codes page, restricts onto to admin users