### PR TITLE
fix column name on tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,3 @@
 class Tag < ApplicationRecord
-  validate_uniqueness_of :name
+  validates_uniqueness_of :name
 end

--- a/db/migrate/20170305033808_create_tags.rb
+++ b/db/migrate/20170305033808_create_tags.rb
@@ -1,7 +1,7 @@
 class CreateTags < ActiveRecord::Migration[5.0]
   def change
     create_table :tags do |t|
-      t.string name
+      t.string :name
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20170305035652) do
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string   "CreateTags"
+    t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
To fix this column name, run:
`rake db:migrate:redo VERSION=20170305033808`